### PR TITLE
Fix link to source code repository

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ DEPENDENCIES
   jekyll (= 3.6.3)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.6.5p114
 
 BUNDLED WITH
-   1.13.6
+   1.17.2

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,6 @@ email: help@opendata.by
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "city.opendata.by" # the base hostname & protocol for your site
 #twitter_username: jekyllrb
-github_username:  opendataby
 
 collections:
   indicators:
@@ -31,3 +30,9 @@ collections:
 # Build settings
 markdown: kramdown
 # theme: minima
+
+
+# --- custom variables for city dashboard project ----------------------------
+
+source_repo: "https://github.com/opendataby/city-dashboard"
+

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,11 +22,9 @@
 
       <div class="footer-col footer-col-2">
         <ul class="social-media-list">
-          {% if site.github_username %}
           <li>
-            {% include icon-github.html username=site.github_username %}
+            {% include icon-github.html repo=site.source_repo %}
           </li>
-          {% endif %}
 
           {% if site.twitter_username %}
           <li>

--- a/_includes/icon-github.html
+++ b/_includes/icon-github.html
@@ -1,1 +1,1 @@
-<a href="https://github.com/{{ include.username }}"><span class="icon icon--github">{% include icon-github.svg %}</span><span class="username">{{ include.username }}/city-dashboard</span></a>
+<a href="{{ include.repo }}"><span class="icon icon--github">{% include icon-github.svg %}</span><span>{{ include.repo | split: "/" | last }}</span></a>

--- a/about.md
+++ b/about.md
@@ -4,12 +4,7 @@ title: About
 permalink: /about/
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)
+The website is built with **[Jekyll](http://jekyllrb.com/) {{ jekyll.version }}**.
+You can find out more info about customizing Jekyll theme, as well as basic
+Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/).
 
-You can find the source code for the Jekyll new theme at:
-{% include icon-github.html username="jekyll" %} /
-[minima](https://github.com/jekyll/minima)
-
-You can find the source code for Jekyll at
-{% include icon-github.html username="jekyll" %} /
-[jekyll](https://github.com/jekyll/jekyll)


### PR DESCRIPTION
Current website links to https://github.com/opendataby and it should be https://github.com/opendataby/city-dashboard

All variables defined in `_config.yml` are available as `site.[variable]` including own custom vars, see https://jekyllrb.com/docs/variables/#site-variables 